### PR TITLE
Fix bcal cmac free memleak

### DIFF
--- a/bcal/bcal-basic.c
+++ b/bcal/bcal-basic.c
@@ -62,9 +62,11 @@ void bcal_cipher_free(bcgen_ctx_t *ctx)
         return;
     bc_free_fpt free_fpt;
     free_fpt = (bc_free_fpt) (pgm_read_word(&(ctx->desc_ptr->free)));
-    if (free_fpt)
+    if (free_fpt) {
         free_fpt((ctx->ctx));
-    free(ctx->ctx);
+    } else {
+        free(ctx->ctx);
+    }
 }
 
 void bcal_cipher_enc(void *block, const bcgen_ctx_t *ctx)

--- a/bcal/bcal-cmac.c
+++ b/bcal/bcal-cmac.c
@@ -93,6 +93,7 @@ void bcal_cmac_free(bcal_cmac_ctx_t *ctx)
     free(ctx->accu);
     free(ctx->k1);
     free(ctx->k2);
+    free(ctx->lastblock);
     bcal_cipher_free(&(ctx->cctx));
 }
 


### PR DESCRIPTION
Fixed missing free on 'ctx->lastblock'.
This caused a memleak when using 'bcal_cmac_init'.